### PR TITLE
release 1.0.1 chart

### DIFF
--- a/charts/datawolf/Chart.yaml
+++ b/charts/datawolf/Chart.yaml
@@ -8,7 +8,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.0
+version: 1.0.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -38,4 +38,6 @@ dependencies:
 # annotations for artifact.io
 annotations:
   artifacthub.io/changes: |
-    - initial version of datawolf
+    - add ability to set dataset permission (public/private) 
+    - fix Chart.yaml
+    - fix ingress (deploy at /datawolf)

--- a/charts/datawolf/templates/deployment.yaml
+++ b/charts/datawolf/templates/deployment.yaml
@@ -55,6 +55,8 @@ spec:
               value: {{ join "," .Values.auth.admins | quote }}
             - name: DATAWOLF_USE_AUTH
               value: {{ .Values.auth.enabled | quote }}
+            - name: DATASET_PERMISSION
+              value: {{ .Values.dataset | quote }}
             - name: DB_SOURCE_URL
               value: "jdbc:{{ include "datawolf.postgresql" . }}"
             - name: DB_MAX_POOLSIZE

--- a/charts/datawolf/templates/deployment.yaml
+++ b/charts/datawolf/templates/deployment.yaml
@@ -55,7 +55,7 @@ spec:
               value: {{ join "," .Values.auth.admins | quote }}
             - name: DATAWOLF_USE_AUTH
               value: {{ .Values.auth.enabled | quote }}
-            - name: DATASET_PERMISSION
+            - name: DATASET_PERMISSIONS
               value: {{ .Values.dataset | quote }}
             - name: DB_SOURCE_URL
               value: "jdbc:{{ include "datawolf.postgresql" . }}"

--- a/charts/datawolf/templates/ingress.yaml
+++ b/charts/datawolf/templates/ingress.yaml
@@ -30,7 +30,7 @@ spec:
     - host: {{ . | quote }}
       http:
         paths:
-          - path: /
+          - path: /datawolf
             pathType: ImplementationSpecific
             backend:
               service:

--- a/charts/datawolf/values.yaml
+++ b/charts/datawolf/values.yaml
@@ -13,6 +13,7 @@ nameOverride: ""
 fullnameOverride: ""
 
 loglevel: INFO
+dataset: private
 
 auth:
   enabled: false


### PR DESCRIPTION
- add ability to set dataset permission (public/private)
- fix Chart.yaml
- fix ingress (deploy at /datawolf)