### PR TITLE
Fixes #28 - added the user/creator information to environment of process running tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Added
+- User information to environment of process running the tool [#28](https://github.com/ncsa/datawolf/issues/28)
+
+
 ### Changed
 - Kubernetes executor prints exception [#23](https://github.com/ncsa/datawolf/issues/23)
 

--- a/datawolf-core/src/main/java/edu/illinois/ncsa/datawolf/Executor.java
+++ b/datawolf-core/src/main/java/edu/illinois/ncsa/datawolf/Executor.java
@@ -36,6 +36,8 @@ import edu.illinois.ncsa.domain.dao.FileDescriptorDao;
 public abstract class Executor {
     private static Logger       logger      = LoggerFactory.getLogger(Executor.class);
 
+    protected static String DATAWOLF_USER = "DATAWOLF_USER";
+
     private StringBuilder       log         = new StringBuilder();
     private LogFile             logfile     = new LogFile();
     private int                 lastsave    = 0;

--- a/datawolf-core/src/main/java/edu/illinois/ncsa/datawolf/Executor.java
+++ b/datawolf-core/src/main/java/edu/illinois/ncsa/datawolf/Executor.java
@@ -36,7 +36,7 @@ import edu.illinois.ncsa.domain.dao.FileDescriptorDao;
 public abstract class Executor {
     private static Logger       logger      = LoggerFactory.getLogger(Executor.class);
 
-    protected static String DATAWOLF_USER = "DATAWOLF_USER";
+    protected static String DATAWOLF_USER   = "DATAWOLF_USER";
 
     private StringBuilder       log         = new StringBuilder();
     private LogFile             logfile     = new LogFile();

--- a/datawolf-executor-commandline/src/main/java/edu/illinois/ncsa/datawolf/executor/commandline/CommandLineExecutor.java
+++ b/datawolf-executor-commandline/src/main/java/edu/illinois/ncsa/datawolf/executor/commandline/CommandLineExecutor.java
@@ -108,6 +108,12 @@ public class CommandLineExecutor extends LocalExecutor {
                 env.putAll(impl.getEnv());
             }
 
+            // Add user to the environment in case a tool needs this information
+            if(execution.getCreator() != null) {
+                String user = execution.getCreator().getEmail();
+                env.put(DATAWOLF_USER, user);
+            }
+
             // find the app to execute
             command.add(findApp(impl.getExecutable().trim(), cwd));
 

--- a/datawolf-executor-kubernetes/src/main/java/edu/illinois/ncsa/datawolf/executor/kubernetes/KubernetesExecutor.java
+++ b/datawolf-executor-kubernetes/src/main/java/edu/illinois/ncsa/datawolf/executor/kubernetes/KubernetesExecutor.java
@@ -285,8 +285,25 @@ public class KubernetesExecutor extends RemoteExecutor {
             container.args(command);
             // add any environment variables
             if (!impl.getEnv().isEmpty()) {
-                // TODO implement
-                //container.addEnvItem();
+                Map<String, String> environment = impl.getEnv();
+
+                for (Map.Entry<String, String> entry : environment.entrySet()) {
+                    String key = entry.getKey();
+                    String value = entry.getValue();
+                    V1EnvVar envVar = new V1EnvVar();
+                    envVar.setName(key);
+                    envVar.setValue(value);
+                    container.addEnvItem(envVar);
+                }
+            }
+
+            // Add user to the environment in case a tool needs this information
+            if(execution.getCreator() != null) {
+                String user = execution.getCreator().getEmail();
+                V1EnvVar envVar = new V1EnvVar();
+                envVar.setName(DATAWOLF_USER);
+                envVar.setValue(user);
+                container.addEnvItem(envVar);
             }
 
             // add resource limits


### PR DESCRIPTION
Tools that access other resources (e.g. external files/services) might need to know who is executing the tool so they can communicate that to the other services. This PR adds the datawolf user that created the execution to the environment. 