### PR TITLE
Fixes #39 changed WorkflowToolData to allow optional datasets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+- WorkflowToolData to allow optional datasets [#39](https://github.com/ncsa/datawolf/issues/39)
+
 
 ## [4.7.0] - 2024-10-29
 

--- a/datawolf-domain/src/main/java/edu/illinois/ncsa/datawolf/domain/WorkflowToolData.java
+++ b/datawolf-domain/src/main/java/edu/illinois/ncsa/datawolf/domain/WorkflowToolData.java
@@ -51,6 +51,9 @@ public class WorkflowToolData extends AbstractBean {
     /** Mime type of the workflow tool data */
     private String            mimeType         = "";                          //$NON-NLS-1$
 
+    /** Can the dataset be null */
+    private boolean           allowNull        = false;
+
     /**
      * Create a new instance of the workflow tool.
      */
@@ -68,7 +71,7 @@ public class WorkflowToolData extends AbstractBean {
     /**
      * Sets the id of the workflow tool data
      * 
-     * @param id
+     * @param dataid
      *            sets the id of the workflow tool data.
      * 
      */
@@ -134,6 +137,25 @@ public class WorkflowToolData extends AbstractBean {
      */
     public void setMimeType(String mimeType) {
         this.mimeType = mimeType;
+    }
+
+    /**
+     * Return true if the dataset is allowed to be empty.
+     *
+     * @return the true if the parameter can be empty.
+     */
+    public boolean isAllowNull() {
+        return allowNull;
+    }
+
+    /**
+     * Sets whether the workflow dataset can be empty.
+     *
+     * @param allowNull
+     *            the allowNull to set
+     */
+    public void setAllowNull(boolean allowNull) {
+        this.allowNull = allowNull;
     }
 
     @Override

--- a/datawolf-executor-commandline/src/main/java/edu/illinois/ncsa/datawolf/executor/commandline/CommandLineExecutor.java
+++ b/datawolf-executor-commandline/src/main/java/edu/illinois/ncsa/datawolf/executor/commandline/CommandLineExecutor.java
@@ -159,6 +159,11 @@ public class CommandLineExecutor extends LocalExecutor {
 
                     if (option.getInputOutput() != InputOutput.OUTPUT) {
                         String key = step.getInputs().get(option.getOptionId());
+                        if (execution.getDataset(key).isEmpty()) {
+                            // No dataset has been set, must be an optional dataset so skip it
+                            break;
+                        }
+
                         Dataset ds = datasetDao.findOne(execution.getDataset(key));// option.getOptionId()));
                         if (ds == null) {
                             throw (new AbortException("Dataset is missing."));

--- a/datawolf-executor-hpc/src/main/java/edu/illinois/ncsa/datawolf/executor/hpc/HPCExecutor.java
+++ b/datawolf-executor-hpc/src/main/java/edu/illinois/ncsa/datawolf/executor/hpc/HPCExecutor.java
@@ -205,6 +205,10 @@ public class HPCExecutor extends RemoteExecutor {
                             String optionId = option.getOptionId();
                             Map<String, String> inputs = step.getInputs();
                             String key = inputs.get(optionId);
+                            if (execution.getDataset(key).isEmpty()) {
+                                // No dataset has been set, must be an optional dataset so skip it
+                                break;
+                            }
                             Dataset ds = datasetDao.findOne(execution.getDataset(key));
                             if (ds == null) {
                                 throw (new AbortException("Dataset is missing."));

--- a/datawolf-executor-java/src/main/java/edu/illinois/ncsa/datawolf/executor/java/JavaExecutor.java
+++ b/datawolf-executor-java/src/main/java/edu/illinois/ncsa/datawolf/executor/java/JavaExecutor.java
@@ -149,6 +149,10 @@ public class JavaExecutor extends LocalExecutor {
                 // set inputs
                 if (tool.getInputs() != null) {
                     for (Entry<String, String> entry : step.getInputs().entrySet()) {
+                        if (execution.getDataset(entry.getValue()).isEmpty()) {
+                            // No dataset has been set, must be an optional dataset so skip it
+                            break;
+                        }
                         Dataset ds = datasetDao.findOne(execution.getDataset(entry.getValue()));
                         if (ds == null) {
                             throw (new AbortException("Dataset is missing."));

--- a/datawolf-executor-kubernetes/src/main/java/edu/illinois/ncsa/datawolf/executor/kubernetes/KubernetesExecutor.java
+++ b/datawolf-executor-kubernetes/src/main/java/edu/illinois/ncsa/datawolf/executor/kubernetes/KubernetesExecutor.java
@@ -139,6 +139,11 @@ public class KubernetesExecutor extends RemoteExecutor {
 
                     if (option.getInputOutput() != InputOutput.OUTPUT) {
                         String key = step.getInputs().get(option.getOptionId());
+                        if (execution.getDataset(key).isEmpty()) {
+                            // No dataset has been set, must be an optional dataset so skip it
+                            break;
+                        }
+
                         Dataset ds = datasetDao.findOne(execution.getDataset(key));// option.getOptionId()));
                         if (ds == null) {
                             throw (new AbortException("Dataset is missing."));

--- a/datawolf-jpa/src/main/resources/META-INF/orm.xml
+++ b/datawolf-jpa/src/main/resources/META-INF/orm.xml
@@ -220,6 +220,7 @@
 			<basic name="title" />
 			<basic name="description" />
 			<basic name="mimeType" />
+			<basic name="allowNull" />
 		</attributes>
 	</entity>
 	<entity class="WorkflowToolParameter" name="WorkflowToolParameter">
@@ -237,3 +238,4 @@
 	</entity>
 	<!-- how to handle enum types? -->
 </entity-mappings>
+


### PR DESCRIPTION
Added a new parameter to WorkflowToolData to allow setting inputs as optional. I also updated the executors to handle the case where there is no data set for an optional input.

This is a breaking change since older datawolf instances will not have the new parameter. It's a fairly simple fix to update the WorkfowToolData table with:

ALTER TABLE WorkflowToolData ADD COLUMN "allownull" BOOLEAN DEFAULT FALSE;