### PR TITLE
Fixes #41 where wildcard flags used for storing output datasets did not fail steps where no outputs found

### DIFF
--- a/datawolf-executor-commandline/src/main/java/edu/illinois/ncsa/datawolf/executor/commandline/CommandLineExecutor.java
+++ b/datawolf-executor-commandline/src/main/java/edu/illinois/ncsa/datawolf/executor/commandline/CommandLineExecutor.java
@@ -428,11 +428,21 @@ public class CommandLineExecutor extends LocalExecutor {
                             }
                         });
 
-                        for (File file : files) {
-                            logger.debug("adding files to a dataset: " + file);
-                            FileInputStream fis = new FileInputStream(file);
-                            fileStorage.storeFile(file.getName(), fis, execution.getCreator(), ds);
-                            fis.close();
+                        if (files != null) {
+                            // TODO - once optional datasets is merged, add allow null check for optional datasets
+//                            if (files.length == 0 && (!step.getTool().getOutput(entry.getKey()).isAllowNull())) {
+                            if(files.length == 0) {
+                                // Required output was not found, fail the step
+                                logger.error("Could not find required output files, failing the workflow step.");
+                                throw new FailedException("Required output files are missing.");
+                            }
+
+                            for (File file : files) {
+                                logger.debug("adding files to a dataset: " + file);
+                                FileInputStream fis = new FileInputStream(file);
+                                fileStorage.storeFile(file.getName(), fis, execution.getCreator(), ds);
+                                fis.close();
+                            }
                         }
 
                     } else {

--- a/datawolf-executor-kubernetes/src/main/java/edu/illinois/ncsa/datawolf/executor/kubernetes/KubernetesExecutor.java
+++ b/datawolf-executor-kubernetes/src/main/java/edu/illinois/ncsa/datawolf/executor/kubernetes/KubernetesExecutor.java
@@ -439,11 +439,21 @@ public class KubernetesExecutor extends RemoteExecutor {
                                     }
                                 });
 
-                                for (File file : files) {
-                                    logger.debug("adding files to a dataset: " + file);
-                                    FileInputStream fis = new FileInputStream(file);
-                                    fileStorage.storeFile(file.getName(), fis, execution.getCreator(), ds);
-                                    fis.close();
+                                if (files != null) {
+                                    // TODO - once optional datasets is merged, add allow null check for optional datasets
+//                                if (files.length == 0 && (!step.getTool().getOutput(entry.getKey()).isAllowNull())) {
+                                    if (files.length == 0) {
+                                        // Required output was not found, fail the step
+                                        logger.error("Could not find required output files, failing the workflow step.");
+                                        throw new FailedException("Required output files are missing.");
+                                    }
+
+                                    for (File file : files) {
+                                        logger.debug("adding files to a dataset: " + file);
+                                        FileInputStream fis = new FileInputStream(file);
+                                        fileStorage.storeFile(file.getName(), fis, execution.getCreator(), ds);
+                                        fis.close();
+                                    }
                                 }
 
                             } else {


### PR DESCRIPTION
When a tool creator specifies an exact file to look for after the tool executes, DataWolf attempts to read the file specified and if it's not found, it throws an exception that fails the step. However, in the case where a tool creator specifies a wildcard to find the output files, when the tool finishes, a file filter is used to find files that match the expression. If no files are found, then there is no attempt to read any files and no exception gets thrown. I've added a check that if the files list is empty, it should throw a failed exception. 