### PR TITLE
Fixes #44 - build failure from update to maven assembly plugin configuration element

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+- Build failure from update to maven assembly plugin configuration element [#44](https://github.com/ncsa/datawolf/issues/44)
+
 
 ## [4.7.0] - 2024-10-29
 

--- a/datawolf-editor/pom.xml
+++ b/datawolf-editor/pom.xml
@@ -41,7 +41,9 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-assembly-plugin</artifactId>
 				<configuration>
-					<descriptor>src/assembly/bin.xml</descriptor>
+					<descriptors>
+						<descriptor>src/assembly/bin.xml</descriptor>
+					</descriptors>
 				</configuration>
 				<executions>
 					<execution>

--- a/datawolf-provenance/pom.xml
+++ b/datawolf-provenance/pom.xml
@@ -41,7 +41,9 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-assembly-plugin</artifactId>
 				<configuration>
-					<descriptor>src/assembly/bin.xml</descriptor>
+					<descriptors>
+						<descriptor>src/assembly/bin.xml</descriptor>
+					</descriptors>
 				</configuration>
 				<executions>
 					<execution>

--- a/datawolf-tool-creator/pom.xml
+++ b/datawolf-tool-creator/pom.xml
@@ -61,7 +61,9 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-assembly-plugin</artifactId>
 				<configuration>
-					<descriptor>src/assembly/bin.xml</descriptor>
+					<descriptors>
+						<descriptor>src/assembly/bin.xml</descriptor>
+					</descriptors>
 				</configuration>
 				<executions>
 					<execution>

--- a/datawolf-webapp-all/pom.xml
+++ b/datawolf-webapp-all/pom.xml
@@ -122,7 +122,9 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-assembly-plugin</artifactId>
 				<configuration>
-					<descriptor>src/assembly/bin.xml</descriptor>
+					<descriptors>
+						<descriptor>src/assembly/bin.xml</descriptor>
+					</descriptors>
 				</configuration>
 				<executions>
 					<execution>

--- a/datawolf-webapp/pom.xml
+++ b/datawolf-webapp/pom.xml
@@ -76,7 +76,9 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-assembly-plugin</artifactId>
 				<configuration>
-					<descriptor>src/assembly/bin.xml</descriptor>
+					<descriptors>
+						<descriptor>src/assembly/bin.xml</descriptor>
+					</descriptors>
 				</configuration>
 				<executions>
 					<execution>


### PR DESCRIPTION
The latest maven assembly plugin required the <descriptor> element be put in a parent tag called <descriptors>. 