### PR TITLE
Updated the logic for checking if steps are ready and optional datasets

### DIFF
--- a/datawolf-core/src/main/java/edu/illinois/ncsa/datawolf/Engine.java
+++ b/datawolf-core/src/main/java/edu/illinois/ncsa/datawolf/Engine.java
@@ -602,11 +602,11 @@ public class Engine {
                                         for (String id : step.getInputs().values()) {
                                             if (execution != null) {
                                                 boolean allowNull = requiredInputs.get(id);
-                                                if (!execution.hasDataset(id) && !allowNull) {
+                                                if (!execution.hasDataset(id)) {
                                                     logger.debug("Waiting for input with id "+id);
                                                     canrun = 1;
                                                 } else if (execution.getDataset(id) == null && !allowNull) {
-                                                    logger.debug("Found unexpectd null for input with id "+id);
+                                                    logger.debug("Found unexpected null for input with id "+id);
                                                     canrun = 2;
                                                 } else if (Execution.EMPTY_DATASET.equals(execution.getDataset(id)) && !allowNull) {
                                                     logger.debug("Found unexpected error for input with id "+id);


### PR DESCRIPTION
The logic still wasn't quite right for optional datasets. The assumption is that if a dataset is optional, a user should still put an entry in the job submission with an empty value. This way, if a step is waiting for an input AND there is no entry yet in the execution dataset map, then we know the step that produces it is still running/queued. If the step fails, then there will be an entry and the engine should handle this case and let the step waiting for the input run since allowNull is ok. 

The problem with the previous logic was if a step was running/queued/waiting and an output is connected to an optional input, there was no entry yet, allowNull let the next step proceed and that's not right. The next step expected an entry and caused a NPE because there should be "something" in the dataset map if the step that produces it finished/failed or if the user submitted the job and was not setting and input for that. 

TLDR:
The logic now is a user must set an empty input for optional datasets if a step's output is not connected to the input for a step. This way the engine knows if it should keep waiting. 